### PR TITLE
Add `SystemPricesFetcher Class` to get System Buy Prices

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -16,3 +16,4 @@ jobs:
       pytest_cov_dir: "pyElexon"
       python-version: "['3.10','3.11']"
       os_list: '["ubuntu-latest"]'
+      extra_commands: "pip3 install -e '.[all]'"

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -13,7 +13,7 @@ jobs:
     uses: openclimatefix/.github/.github/workflows/python-test.yml@main
     with:
       # pytest-cov looks at this folder
-      pytest_cov_dir: "pyElexon"
+      pytest_cov_dir: "pyelexon"
       python-version: "['3.10','3.11']"
       os_list: '["ubuntu-latest"]'
       extra_commands: "pip3 install -e '.[all]'"

--- a/pyelexon/system/system_module.py
+++ b/pyelexon/system/system_module.py
@@ -43,3 +43,4 @@ class SystemPricesFetcher:
         except Exception as err:
             print(f"Other error occurred: {err}")
             raise
+

--- a/pyelexon/system/system_module.py
+++ b/pyelexon/system/system_module.py
@@ -32,9 +32,7 @@ class SystemPricesFetcher:
             data = response.json()
             df = pd.DataFrame(data["data"])
 
-            # Filter to include only the 'systemBuyPrice' column
-            buy_prices_df = df[['settlementDate', 'settlementPeriod', 'systemBuyPrice']]
-            return buy_prices_df
+            return df  # Return entire DataFrame
 
         except requests.exceptions.HTTPError as http_err:
             print(f"HTTP error occurred: {http_err}")

--- a/pyelexon/system/system_module.py
+++ b/pyelexon/system/system_module.py
@@ -1,0 +1,45 @@
+from typing import Union
+from datetime import datetime
+import pandas as pd
+import requests
+from pyelexon.constants import BASE_URL
+
+class SystemPricesFetcher:
+    def __init__(self):
+        pass
+
+    def get_buy_prices(self, settlement_date: Union[datetime, str]) -> pd.DataFrame:
+        """
+        Parameters:
+            settlement_date (Union[datetime, str]): The settlement date to fetch data for.
+
+        Returns:
+            pd.DataFrame: DataFrame containing system buy prices data.
+
+        API Documentation:
+        For more details on this API endpoint, refer to the : https://bmrs.elexon.co.uk/api-documentation/endpoint/balancing/settlement/system-prices/%7BsettlementDate%7D/%7BsettlementPeriod%7D
+
+        """
+        if isinstance(settlement_date, datetime):
+            settlement_date = settlement_date.strftime('%Y-%m-%d')
+
+        url = f"{BASE_URL}/balancing/settlement/system-prices/{settlement_date}?format=json"
+
+        try:
+            response = requests.get(url)
+            response.raise_for_status()  # Raise HTTPError for bad responses (4xx or 5xx)
+
+            data = response.json()
+            df = pd.DataFrame(data["data"])
+
+            # Filter to include only the 'systemBuyPrice' column
+            buy_prices_df = df[['settlementDate', 'settlementPeriod', 'systemBuyPrice']]
+            return buy_prices_df
+
+        except requests.exceptions.HTTPError as http_err:
+            print(f"HTTP error occurred: {http_err}")
+            raise
+
+        except Exception as err:
+            print(f"Other error occurred: {err}")
+            raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ license={file="LICENCE"}
 dependencies = [
     "pandas",
     "requests<2.32.0",
+    "requests-mock"
 ]
 
 [tool.setuptools.dynamic]
@@ -25,6 +26,7 @@ dev=[
     "pre-commit",
     "pytest",
     "pytest-cov",
+    "pytest-mock"
 ]
 
 all=["pyelexon[dev]"]

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,6 +1,10 @@
+import os
+import sys
 import pytest
 import pandas as pd
 from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from pyelexon.datasets import Datasets
 import requests
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -2,15 +2,16 @@ import os
 import sys
 import pytest
 import pandas as pd
-from unittest.mock import patch, MagicMock
+from unittest import mock
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from pyelexon.datasets import Datasets
 import requests
 
 @pytest.fixture
-def mock_requests_get(mocker):
-    return mocker.patch('requests.get')
+def mock_requests_get():
+    with mock.patch('requests.get') as mock_get:
+        yield mock_get
 
 def test_fetch_data_dict_response(mock_requests_get):
     # Mock response data for dict response

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -3,8 +3,6 @@ import sys
 import pytest
 import pandas as pd
 from unittest import mock
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from pyelexon.datasets import Datasets
 import requests
 

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -5,9 +5,6 @@ import requests
 import requests_mock
 from datetime import datetime
 import pandas as pd
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 from pyelexon.constants import BASE_URL
 from pyelexon.system.system_module import SystemPricesFetcher
 

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1,0 +1,71 @@
+import os
+import sys
+import pytest
+import requests
+import requests_mock
+from datetime import datetime
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from pyelexon.constants import BASE_URL
+from pyelexon.system.system_module import SystemPricesFetcher
+
+@pytest.fixture
+def fetcher():
+    return SystemPricesFetcher()
+
+def test_get_buy_prices_with_datetime(fetcher):
+    settlement_date = datetime(2023, 7, 1)
+    expected_date_str = settlement_date.strftime('%Y-%m-%d')
+
+    with requests_mock.Mocker() as m:
+        url = f"{BASE_URL}/balancing/settlement/system-prices/{expected_date_str}?format=json"
+        m.get(url, json={
+            "data": [
+                {"settlementDate": "2023-07-01", "settlementPeriod": "1", "systemBuyPrice": 50.0}
+            ]
+        })
+
+        df = fetcher.get_buy_prices(settlement_date)
+        assert not df.empty
+        assert df.shape[0] == 1
+        assert list(df.columns) == ['settlementDate', 'settlementPeriod', 'systemBuyPrice']
+        assert df.iloc[0]['systemBuyPrice'] == 50.0
+
+def test_get_buy_prices_with_string(fetcher):
+    settlement_date = "2023-07-01"
+
+    with requests_mock.Mocker() as m:
+        url = f"{BASE_URL}/balancing/settlement/system-prices/{settlement_date}?format=json"
+        m.get(url, json={
+            "data": [
+                {"settlementDate": "2023-07-01", "settlementPeriod": "1", "systemBuyPrice": 50.0}
+            ]
+        })
+
+        df = fetcher.get_buy_prices(settlement_date)
+        assert not df.empty
+        assert df.shape[0] == 1
+        assert list(df.columns) == ['settlementDate', 'settlementPeriod', 'systemBuyPrice']
+        assert df.iloc[0]['systemBuyPrice'] == 50.0
+
+def test_get_buy_prices_invalid_date(fetcher):
+    settlement_date = "invalid-date"
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        with requests_mock.Mocker() as m:
+            url = f"{BASE_URL}/balancing/settlement/system-prices/{settlement_date}?format=json"
+            m.get(url, status_code=400)
+
+            fetcher.get_buy_prices(settlement_date)
+
+def test_get_buy_prices_api_failure(fetcher):
+    settlement_date = "2023-07-01"
+
+    with pytest.raises(Exception):
+        with requests_mock.Mocker() as m:
+            url = f"{BASE_URL}/balancing/settlement/system-prices/{settlement_date}?format=json"
+            m.get(url, status_code=500)
+
+            fetcher.get_buy_prices(settlement_date)


### PR DESCRIPTION
## Description
This pull request has a new class, `SystemPricesFetcher`, which retrieves system buy prices from Elexon API. The class provides a method to fetch and return the buy prices as a pandas data frame.

The method returns a data frame structured as follows:

![image](https://github.com/openclimatefix/pyElexon/assets/41283476/fb32a7dd-635a-4b81-a83d-02e599f2ae72)


## Checklist:
- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my code
- [X] I have checked my code and corrected any misspellings
